### PR TITLE
Removing upstream repo reference in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Quick Create Link Coming Soon...
 ### Option 2) AWS CDK Deployment
 
 ```bash
-git clone https://github.com/aws-samples/aws-startup-blueprint.git
+git clone https://github.com/aws-quickstart/quickstart-aws-biotech-blueprint-cdk.git
 npm run build 
 cdk bootstrap
 ```


### PR DESCRIPTION
Silly vestigial reference in the readme to an upstream repo. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
